### PR TITLE
Swap action button fix

### DIFF
--- a/src/components/common/ActionButton/ActionButton.module.css
+++ b/src/components/common/ActionButton/ActionButton.module.css
@@ -40,7 +40,7 @@
 }
 
 .primary {
-  color: var(--button-content-primary);
+  color: var(--content-inverse);
   background-color: var(--button-primary);
 }
 

--- a/src/components/common/Swap/Swap.tsx
+++ b/src/components/common/Swap/Swap.tsx
@@ -630,6 +630,8 @@ const Swap = () => {
               variant="primary"
               onClick={connect}
               loading={isConnecting}
+              size={"big"}
+              fullWidth
             >
               Connect Wallet
             </ActionButton>
@@ -641,6 +643,8 @@ const Swap = () => {
               onClick={handleSwapClick}
               loading={isActionLoading}
               className={clsx(isActionLoading && styles.btnLoading)}
+              size={"big"}
+              fullWidth
             >
               {swapButtonTitle}
             </ActionButton>


### PR DESCRIPTION
Fixes:

1. The Swap button is smaller in the swap window, does not look like it is intentional
2. The swap button color text is currently set to #0e111e but in figma it is #28282F. The font color of all action button needs to be updated to this value


https://pentagonstudio.neetorecord.com/watch/b7855986b4acc171d426
https://pentagonstudio.neetorecord.com/watch/802a05a0e94bdcf9e7ec