### PR TITLE
Liquidity and boost banner fix

### DIFF
--- a/src/components/common/PromoBlock/PromoBlock.module.css
+++ b/src/components/common/PromoBlock/PromoBlock.module.css
@@ -4,7 +4,7 @@
   gap: 10px;
   padding: 12px;
   background-color: var(--background-secondary);
-  border-radius: 12px;
+  border-radius: 16px;
   border: 11px solid var(--background-tertiary);
 }
 

--- a/src/components/pages/liquidity-page/LiquidityPageLayout.tsx
+++ b/src/components/pages/liquidity-page/LiquidityPageLayout.tsx
@@ -32,22 +32,22 @@ const LiquidityPageLayout = (): JSX.Element => {
               <Image
                 src={LearnMoreIcon}
                 alt={"learn more"}
-                width={40}
-                height={40}
+                width={48}
+                height={48}
                 priority
               />
             }
             title="Learn about providing liquidity"
             link={LIQUIDITY_PROVIDING_DOC_URL}
-            linkText="Click here to see the guide"
+            linkText="Click here and check our v3 LP walktrought"
           />
           <PromoBlock
             icon={
               <Image
                 src={BoostIcon}
                 alt={"boost icon"}
-                width={40}
-                height={40}
+                width={48}
+                height={48}
                 priority
               />
             }

--- a/src/components/pages/view-position-page/components/PositionView/DesktopPositionView/DesktopPositionView.tsx
+++ b/src/components/pages/view-position-page/components/PositionView/DesktopPositionView/DesktopPositionView.tsx
@@ -130,14 +130,14 @@ const DesktopPositionView = ({
           <Image
             src={LearnMoreIcon}
             alt={"learn more"}
-            width={40}
-            height={40}
+            width={48}
+            height={48}
             priority
           />
         }
         title="Learn about providing liquidity"
         link={LIQUIDITY_PROVIDING_DOC_URL}
-        linkText="Click here to see the guide"
+        linkText="Click here and check our v3 LP walktrought"
       />
     </section>
   );

--- a/src/components/pages/view-position-page/components/PositionView/MobilePositionView/MobilePositionView.tsx
+++ b/src/components/pages/view-position-page/components/PositionView/MobilePositionView/MobilePositionView.tsx
@@ -136,7 +136,7 @@ const MobilePositionView = ({
         }
         title="Learn about providing liquidity"
         link={LIQUIDITY_PROVIDING_DOC_URL}
-        linkText="Click here to see the guide"
+        linkText="Click here and check our v3 LP walktrought"
       />
     </section>
   );


### PR DESCRIPTION
Fixes:

1. The badge at the bottom of the liquidity page needs to be bigger - https://pentagonstudio.neetorecord.com/watch/c41b080644118e174740
2. Inner radius of Banner at the bottom is not rounded - https://pentagonstudio.neetorecord.com/watch/2c88e158d0533c6250ff
3. Text is different under the banner to learn more about providing liquidity - https://pentagonstudio.neetorecord.com/watch/362e55baafa6fb71e5bf