### PR TITLE
Manange position/Add liquidity button fix

### DIFF
--- a/src/components/pages/liquidity-page/components/Pools/DesktopPools/DesktopPoolRow.tsx
+++ b/src/components/pages/liquidity-page/components/Pools/DesktopPools/DesktopPoolRow.tsx
@@ -51,7 +51,7 @@ const DesktopPoolRow = ({poolData}: Props): JSX.Element => {
           <ActionButton
             className={styles.createButton}
             variant="secondary"
-            fullWidth
+            size="longer"
           >
             Add Liquidity
           </ActionButton>

--- a/src/components/pages/liquidity-page/components/Pools/DesktopPools/DesktopPools.tsx
+++ b/src/components/pages/liquidity-page/components/Pools/DesktopPools/DesktopPools.tsx
@@ -1,6 +1,6 @@
 import styles from "./DesktopPools.module.css";
-import { clsx } from "clsx";
-import { PoolData } from "@/src/hooks/usePoolsData";
+import {clsx} from "clsx";
+import {PoolData} from "@/src/hooks/usePoolsData";
 import DesktopPoolRow from "./DesktopPoolRow";
 import ActionButton from "@/src/components/common/ActionButton/ActionButton";
 import Link from "next/link";
@@ -12,7 +12,7 @@ type Props = {
   handleSort: (key: string) => void;
 };
 
-const DesktopPools = ({ poolsData, orderBy, handleSort }: Props) => {
+const DesktopPools = ({poolsData, orderBy, handleSort}: Props) => {
   if (!poolsData) {
     return null;
   }
@@ -38,7 +38,7 @@ const DesktopPools = ({ poolsData, orderBy, handleSort }: Props) => {
           />
           <th>
             <Link href="/liquidity/create-pool">
-              <ActionButton className={styles.createButton} fullWidth>
+              <ActionButton className={styles.createButton} size={"longer"}>
                 Create Pool
               </ActionButton>
             </Link>

--- a/src/components/pages/liquidity-page/components/Positions/MobilePositions/DesktopPositions/DesktopPosition.tsx
+++ b/src/components/pages/liquidity-page/components/Positions/MobilePositions/DesktopPositions/DesktopPosition.tsx
@@ -90,7 +90,11 @@ export const DesktopPosition = ({
       </td>
       <td className={styles.labelCell}>
         <Link href={positionPath}>
-          <ActionButton className={styles.addButton} variant="secondary">
+          <ActionButton
+            className={styles.addButton}
+            variant="secondary"
+            size={"longer"}
+          >
             Manage position
           </ActionButton>
         </Link>


### PR DESCRIPTION
Fixes:

1. The minimum width of the manage position button can be increased to 175px with the padding adjusted to 16px from the current 12px. Please use your discretion for this change. The same goes for the Add liquidity button.

https://pentagonstudio.neetorecord.com/watch/c186de61000ae2e5c620