### PR TITLE
Coin list item font styles fix [by ajayjose]

### DIFF
--- a/src/components/common/Coin/Coin.tsx
+++ b/src/components/common/Coin/Coin.tsx
@@ -36,8 +36,8 @@ const Coin = ({assetId, className, onClick}: Props) => {
         <Image
           src={icon}
           alt={`${metadata.symbol} icon`}
-          width={25}
-          height={25}
+          width={24}
+          height={24}
           priority
         />
       ) : null}

--- a/src/components/common/Swap/components/CoinListItem/CoinListItem.module.css
+++ b/src/components/common/Swap/components/CoinListItem/CoinListItem.module.css
@@ -33,14 +33,14 @@
 }
 
 .name {
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 22px;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 100%;
 }
 
 .fullName {
-  font-size: 14px;
-  line-height: 16px;
+  font-size: 15px;
+  line-height: 100%;
   color: var(--content-dimmed-light);
 }
 


### PR DESCRIPTION
- The Coin list title can have the font increased to 19, line height to 100% and font weight to 500
- The coin list full name can have the font size increased to 15px with 100% kline height. This comes rrightly below the coin list title mentioned above
- The width of the coin icon is currently set to 25px, this needs to be 24px
