### PR TITLE
Slippage settings layout fix

### DIFF
--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -22,7 +22,7 @@ const Footer = ({isHomePage = false}: FooterProps) => {
             <Logo isFooter={true} />
             <div className={styles.linksAndSocial}>
               <div className={styles.links}>
-                <a className={styles.link} href={DiscordLink}>
+                <a className={styles.link} href={DiscordLink} target="_blank">
                   Support
                 </a>
                 <a

--- a/src/components/common/Swap/Swap.tsx
+++ b/src/components/common/Swap/Swap.tsx
@@ -655,7 +655,10 @@ const Swap = () => {
         </div> */}
       </div>
       {swapPending && <div className={styles.loadingOverlay} />}
-      <SettingsModal title={`Slippage tolerance: ${slippage / 100}%`}>
+      <SettingsModal
+        title={`Slippage tolerance: ${slippage / 100}%`}
+        size={"regular"}
+      >
         <SettingsModalContent slippage={slippage} setSlippage={setSlippage} />
       </SettingsModal>
       <CoinsModal title="Choose token">

--- a/src/components/common/Swap/components/SettingsModalContent/SettingsModalContent.module.css
+++ b/src/components/common/Swap/components/SettingsModalContent/SettingsModalContent.module.css
@@ -1,7 +1,7 @@
 .settingsContainer {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
   margin-bottom: 10px;
 }
 

--- a/src/hooks/useModal/Modal.module.css
+++ b/src/hooks/useModal/Modal.module.css
@@ -47,6 +47,12 @@
   max-width: 460px;
 }
 
+.modalSizeRegular {
+  width: 90%;
+  max-width: 507px;
+  padding: 25px;
+}
+
 .modalSizeLarge {
   width: 90%;
   max-width: 640px;

--- a/src/hooks/useModal/useModal.tsx
+++ b/src/hooks/useModal/useModal.tsx
@@ -13,7 +13,7 @@ type ModalProps = {
   children: ReactNode;
   className?: string;
   onClose?: VoidFunction;
-  size?: "small" | "medium" | "large" | "fullWidth";
+  size?: "small" | "medium" | "large" | "fullWidth" | "regular";
 };
 
 type ReturnType = (props: ModalProps) => ReactPortal | null;


### PR DESCRIPTION
Fixes:

1. Overall padding of the slippage settings modal
2. Gap between items in the modal

https://pentagonstudio.neetorecord.com/watch/d315e80401bf073d9007