### PR TITLE
style(ui): update confirm popup deny button color to design token

### DIFF
--- a/libs/web/src/components/common/ConfirmPopup/ConfirmPopup.module.css
+++ b/libs/web/src/components/common/ConfirmPopup/ConfirmPopup.module.css
@@ -92,7 +92,7 @@
 
 .buttonDeny {
   background: none;
-  color: var(--accent-primary);
+  color: var(--mc-green-2);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
closes #231 

I was still not able to reproduce the issue. But from what I saw in the dev console, the previous color added to the button was overriding the action button style, made changes.